### PR TITLE
support Python 3

### DIFF
--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -26,7 +26,10 @@ __email__ = "shawnl@palantir.com"
 __license__ = "MIT"
 
 import logging
-import Queue
+try:
+    import queue as Queue # module re-named in Python 3
+except ImportError:
+    import Queue
 import sqlite3
 import threading
 import time


### PR DESCRIPTION
Add a little try/except block to support Python 3's re-naming of Queue to queue.

We try to import the modern module name first and fall back to Queue on
ImportError. This ordering is chosen a) if a modern queue module is provided as
a backport or monkey patch[1] this ordering will pick it up and b) trying to be
Python 3 "first" makes one feel all moral, etc :).

[1] cf the "future" library
