### PR TITLE
setup.py: use setuptools to implement "test" command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ __author__ = "Shawn Lee"
 __email__ = "shawnl@palantir.com"
 __license__ = "MIT"
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name="sqlite3worker",
@@ -34,4 +34,5 @@ setup(
     author="Shawn Lee",
     author_email="shawnl@palantir.com",
     packages=["sqlite3worker"],
-    package_dir={"sqlite3worker": "."})
+    package_dir={"sqlite3worker": "."},
+    test_suite="sqlite3worker_test")


### PR DESCRIPTION
Switch from distutils to setuptools to take advantage of:

``` console
$ python setup.py test
```

which will run the test-suite automatically. This is mostly a cosmetic change
but it is the idiomatic way to run the test-suite.
