### PR TITLE
add simple gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Python build files
+__pycache__
+*.pyc
+*.egg-info
+


### PR DESCRIPTION
My natural Software Engineer OCPD is triggered when `git status` reveals `.pyc`
and `__pycache__` files. Add a simple gitignore file to ignore them. This also has
the side-benefit for non-OCPD Software Engineers that they're protected from
fat-fingering compiled bytecode into commits :).
