### PR TITLE
README.md: add note on pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,24 @@ created to address this by bringing the responsibility of managing the threads
 to the python layer and is agnostic to the server setup of sqlite3.
 
 ## Install
+Installation is via the usual ``setup.py`` method:
+
 ```sh
 sudo python setup.py install
+```
+
+Alternatively one can use ``pip`` to install directly from the git repository
+without having to clone first:
+
+```sh
+sudo pip install git+https://github.com/palantir/sqlite3worker#egg=sqlite3worker
+```
+
+One may also use ``pip`` to install on a per-user basis without requiring
+super-user permissions:
+
+```sh
+pip install --user git+https://github.com/palantir/sqlite3worker#egg=sqlite3worker
 ```
 
 ## Example


### PR DESCRIPTION
Add a note to the README on how to install directly from the git repository
without needing to manually check out. Software Engineers are lazy (in the good
way) and so let's remind them that they can save one command's worth of typing!
