### PR TITLE
dbapi interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 __pycache__
 *.pyc
 *.egg-info
-
+*.clean

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,99 @@
 # Python build files
-__pycache__
 *.pyc
-*.egg-info
 *.clean
+*~
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+# command to run tests
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# Automated testing.
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7-dev"
 # command to run tests
 script: python setup.py test

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Alternatively one can use ``pip`` to install directly from the git repository
 without having to clone first:
 
 ```sh
-sudo pip install git+https://github.com/palantir/sqlite3worker#egg=sqlite3worker
+sudo pip install git+https://github.com/dashawn888/sqlite3worker#egg=sqlite3worker
 ```
 
 One may also use ``pip`` to install on a per-user basis without requiring
 super-user permissions:
 
 ```sh
-pip install --user git+https://github.com/palantir/sqlite3worker#egg=sqlite3worker
+pip install --user git+https://github.com/dashawn888/sqlite3worker#egg=sqlite3worker
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ with multiple threads outside of the compile time options.  This library was
 created to address this by bringing the responsibility of managing the threads
 to the python layer and is agnostic to the server setup of sqlite3.
 
+[![Build Status](https://travis-ci.org/dashawn888/sqlite3worker.svg?branch=master)](https://travis-ci.org/dashawn888/sqlite3worker)
+
 ## Install
 You can use pip:
 ```sh

--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ created to address this by bringing the responsibility of managing the threads
 to the python layer and is agnostic to the server setup of sqlite3.
 
 ## Install
-Installation is via the usual ``setup.py`` method:
+You can use pip:
+```sh
+sudo pip install sqlite3worker
+```
 
+You can use setup.py:
 ```sh
 sudo python setup.py install
 ```

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,96 @@
+Sqlite3Worker
+=============
+
+A threadsafe sqlite worker.
+
+This library implements a thread pool pattern with sqlite3 being the
+desired output.
+
+sqllite3 implementation lacks the ability to safely modify the sqlite3
+database with multiple threads outside of the compile time options. This
+library was created to address this by bringing the responsibility of
+managing the threads to the python layer and is agnostic to the server
+setup of sqlite3.
+
+|Build Status|
+
+Install
+-------
+
+You can use pip:
+
+.. code:: sh
+
+    sudo pip install sqlite3worker
+
+You can use setup.py:
+
+.. code:: sh
+
+    sudo python setup.py install
+
+Alternatively one can use ``pip`` to install directly from the git
+repository without having to clone first:
+
+.. code:: sh
+
+    sudo pip install git+https://github.com/dashawn888/sqlite3worker#egg=sqlite3worker
+
+One may also use ``pip`` to install on a per-user basis without
+requiring super-user permissions:
+
+.. code:: sh
+
+    pip install --user git+https://github.com/dashawn888/sqlite3worker#egg=sqlite3worker
+
+Example
+-------
+
+.. code:: python
+
+    from sqlite3worker import Sqlite3Worker
+
+    sql_worker = Sqlite3Worker("/tmp/test.sqlite")
+    sql_worker.execute("CREATE TABLE tester (timestamp DATETIME, uuid TEXT)")
+    sql_worker.execute("INSERT into tester values (?, ?)", ("2010-01-01 13:00:00", "bow"))
+    sql_worker.execute("INSERT into tester values (?, ?)", ("2011-02-02 14:14:14", "dog"))
+
+    results = sql_worker.execute("SELECT * from tester")
+    for timestamp, uuid in results:
+        print(timestamp, uuid)
+
+    sql_worker.close()
+
+When to use sqlite3worker
+-------------------------
+
+If you have multiple threads all needing to write to a sqlite3 database
+this library will serialize the sqlite3 write requests.
+
+When NOT to use sqlite3worker
+-----------------------------
+
+If your code DOES NOT use multiple threads then you don't need to use a
+thread safe sqlite3 implementation.
+
+If you need multiple applications to write to a sqlite3 db then
+sqlite3worker will not protect you from corrupting the data.
+
+Internals
+---------
+
+The library creates a queue to manage multiple queries sent to the
+database. Instead of directly calling the sqlite3 interface, you will
+call the Sqlite3Worker which inserts your query into a Queue.Queue()
+object. The queries are processed in the order that they are inserted
+into the queue (first in, first out). In order to ensure that the
+multiple threads are managed in the same queue, you will need to pass
+the same Sqlite3Worker object to each thread.
+
+Python docs for sqlite3
+-----------------------
+
+https://docs.python.org/2/library/sqlite3.html
+
+.. |Build Status| image:: https://travis-ci.org/dashawn888/sqlite3worker.svg?branch=master
+   :target: https://travis-ci.org/dashawn888/sqlite3worker

--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,7 @@
 """Init."""
 
 __author__ = "Shawn Lee"
-__email__ = "shawnl@palantir.com"
+__email__ = "dashawn@gmail.com"
 __license__ = "MIT"
 
 from sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -23,5 +23,6 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
+__version__ = 1.1
 
 from sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,6 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
-__version__ = 1.1.2
+__version__ = 1.1.3
 
 from sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,7 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 
 try:
     # Python 2

--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,7 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 try:
     # Python 2

--- a/__init__.py
+++ b/__init__.py
@@ -25,4 +25,4 @@ __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
 __version__ = 1.1.4
 
-from sqlite3worker import Sqlite3Worker
+from sqlite3worker.sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,6 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
-__version__ = 1.1.4
+__version__ = "1.1.4"
 
 from sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,6 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
-__version__ = 1.1.4
+__version__ = 1.1.5
 
 from sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,6 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
-__version__ = 1.1
+__version__ = 1.1.2
 
 from sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,6 @@
 __author__ = "Shawn Lee"
 __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
-__version__ = 1.1.3
+__version__ = 1.1.4
 
 from sqlite3worker import Sqlite3Worker

--- a/__init__.py
+++ b/__init__.py
@@ -25,4 +25,9 @@ __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
 __version__ = "1.1.5"
 
-from sqlite3worker.sqlite3worker import Sqlite3Worker
+try:
+    # Python 2
+    from sqlite3worker import Sqlite3Worker
+except ImportError:
+    # Python 3
+    from sqlite3worker.sqlite3worker import Sqlite3Worker

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.rst'):
 
 setup(
         name="sqlite3worker",
-        version="1.1.6",
+        version="1.1.7",
         description=short_description,
         author="Shawn Lee",
         author_email="dashawn@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
     description="Thread safe sqlite3 interface",
     author="Shawn Lee",
     author_email="dashawn@gmail.com",
+    url="https://github.com/dashawn888/sqlite3worker",
     packages=["sqlite3worker"],
     package_dir={"sqlite3worker": "."},
+    keywords=["sqlite", "sqlite3", "thread", "multithread", "multithreading"],
     test_suite="sqlite3worker_test")

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.rst'):
 
 setup(
         name="sqlite3worker",
-        version="1.1.3",
+        version="1.1.4",
         description=short_description,
         author="Shawn Lee",
         author_email="dashawn@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,29 @@ __license__ = "MIT"
 from setuptools import setup
 
 setup(
-    name="sqlite3worker",
-    version="1.1",
-    description="Thread safe sqlite3 interface",
-    author="Shawn Lee",
-    author_email="dashawn@gmail.com",
-    url="https://github.com/dashawn888/sqlite3worker",
-    packages=["sqlite3worker"],
-    package_dir={"sqlite3worker": "."},
-    keywords=["sqlite", "sqlite3", "thread", "multithread", "multithreading"],
-    test_suite="sqlite3worker_test")
+        name="sqlite3worker",
+        version="1.1",
+        description="Thread safe sqlite3 interface",
+        author="Shawn Lee",
+        author_email="dashawn@gmail.com",
+        url="https://github.com/dashawn888/sqlite3worker",
+        packages=["sqlite3worker"],
+        package_dir={"sqlite3worker": "."},
+        keywords=["sqlite", "sqlite3", "thread", "multithread", "multithreading"],
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.0",
+            "Programming Language :: Python :: 3.1",
+            "Programming Language :: Python :: 3.2",
+            "Programming Language :: Python :: 3.3",
+            "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: 3.6",
+            "Topic :: Database"
+            ],
+        test_suite="sqlite3worker_test")

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.rst'):
 
 setup(
         name="sqlite3worker",
-        version="1.1.5",
+        version="1.1.6",
         description=short_description,
         author="Shawn Lee",
         author_email="dashawn@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.rst'):
 
 setup(
         name="sqlite3worker",
-        version="1.1.2",
+        version="1.1.3",
         description=short_description,
         author="Shawn Lee",
         author_email="dashawn@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from setuptools import setup
 
 setup(
     name="sqlite3worker",
-    version="1.0",
+    version="1.1",
     description="Thread safe sqlite3 interface",
     author="Shawn Lee",
     author_email="dashawn@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 """Setup."""
 
 __author__ = "Shawn Lee"
-__email__ = "shawnl@palantir.com"
+__email__ = "dashawn@gmail.com"
 __license__ = "MIT"
 
 from setuptools import setup
@@ -32,7 +32,7 @@ setup(
     version="1.0",
     description="Thread safe sqlite3 interface",
     author="Shawn Lee",
-    author_email="shawnl@palantir.com",
+    author_email="dashawn@gmail.com",
     packages=["sqlite3worker"],
     package_dir={"sqlite3worker": "."},
     test_suite="sqlite3worker_test")

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,17 @@ __email__ = "dashawn@gmail.com"
 __license__ = "MIT"
 
 from setuptools import setup
+import os
+
+short_description="Thread safe sqlite3 interface",
+long_description = short_description
+if os.path.exists('README.rst'):
+    long_description = open('README.rst').read()
 
 setup(
         name="sqlite3worker",
-        version="1.1",
-        description="Thread safe sqlite3 interface",
+        version="1.1.2",
+        description=short_description,
         author="Shawn Lee",
         author_email="dashawn@gmail.com",
         url="https://github.com/dashawn888/sqlite3worker",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if os.path.exists('README.rst'):
 
 setup(
         name="sqlite3worker",
-        version="1.1.4",
+        version="1.1.5",
         description=short_description,
         author="Shawn Lee",
         author_email="dashawn@gmail.com",

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -22,7 +22,7 @@
 """Thread safe sqlite3 interface."""
 
 __author__ = "Shawn Lee"
-__email__ = "shawnl@palantir.com"
+__email__ = "dashawn@gmail.com"
 __license__ = "MIT"
 
 import logging

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2014 Palantir Technologies
 # -*- coding: utf-8 -*-
+# Copyright (c) 2014 Palantir Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -158,6 +158,8 @@ class Sqlite3Worker(threading.Thread):
         # Check that the thread is done before returning.
         self._thread_closed_event.wait()
         self._close_lock.release()
+        while self.is_alive():
+            time.sleep(.1)
 
     @property
     def queue_size(self):

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014 Palantir Technologies
+# -*- coding: utf-8 -*-
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,16 +26,16 @@ __email__ = "shawnl@palantir.com"
 __license__ = "MIT"
 
 import logging
-try:
-    import queue as Queue # module re-named in Python 3
-except ImportError:
-    import Queue
 import sqlite3
 import threading
-import time
 import uuid
 
-LOGGER = logging.getLogger('sqlite3worker')
+try:
+    import queue as Queue  # module re-named in Python 3
+except ImportError:
+    import Queue
+
+LOGGER = logging.getLogger("sqlite3worker")
 
 
 class Sqlite3Worker(threading.Thread):
@@ -52,6 +53,7 @@ class Sqlite3Worker(threading.Thread):
         sql_worker.execute("SELECT * from tester")
         sql_worker.close()
     """
+
     def __init__(self, file_name, max_queue_size=100):
         """Automatically starts the thread.
 
@@ -68,11 +70,13 @@ class Sqlite3Worker(threading.Thread):
         self.sql_queue = Queue.Queue(maxsize=max_queue_size)
         self.results = {}
         self.max_queue_size = max_queue_size
-        self.exit_set = False
-        # Token that is put into queue when close() is called.
-        self.exit_token = str(uuid.uuid4())
+        # Event that is triggered once the run_query has been executed.
+        self.select_event = threading.Event()
+        # Event to start the exit process.
+        self.exit_event = threading.Event()
+        # Event that closes out the threads.
+        self.thread_closed = threading.Event()
         self.start()
-        self.thread_running = True
 
     def run(self):
         """Thread loop.
@@ -88,10 +92,10 @@ class Sqlite3Worker(threading.Thread):
         LOGGER.debug("run: Thread started")
         execute_count = 0
         for token, query, values in iter(self.sql_queue.get, None):
-            LOGGER.debug("sql_queue: %s", self.sql_queue.qsize())
-            if token != self.exit_token:
+            if query:
+                LOGGER.debug("sql_queue: %s", self.sql_queue.qsize())
                 LOGGER.debug("run: %s", query)
-                self.run_query(token, query, values)
+                self._run_query(token, query, values)
                 execute_count += 1
                 # Let the executes build up a little before committing to disk
                 # to speed things up.
@@ -101,15 +105,19 @@ class Sqlite3Worker(threading.Thread):
                     LOGGER.debug("run: commit")
                     self.sqlite3_conn.commit()
                     execute_count = 0
-            # Only exit if the queue is empty. Otherwise keep getting
+                # Wake up the thread waiting on the execution of the select
+                # query.
+                if query.lower().strip().startswith("select"):
+                    self.select_event.set()
+            # Only exit if the queue is empty.  Otherwise keep getting
             # through the queue until it's empty.
-            if self.exit_set and self.sql_queue.empty():
+            if self.exit_event.is_set() and self.sql_queue.empty():
                 self.sqlite3_conn.commit()
                 self.sqlite3_conn.close()
-                self.thread_running = False
+                self.thread_closed.set()
                 return
 
-    def run_query(self, token, query, values):
+    def _run_query(self, token, query, values):
         """Run a query.
 
         Args:
@@ -136,19 +144,23 @@ class Sqlite3Worker(threading.Thread):
                     "Query returned error: %s: %s: %s", query, values, err)
 
     def close(self):
-        """Close down the thread and close the sqlite3 database file."""
-        self.exit_set = True
-        self.sql_queue.put((self.exit_token, "", ""), timeout=5)
-        # Sleep and check that the thread is done before returning.
-        while self.thread_running:
-            time.sleep(.01)  # Don't kill the CPU waiting.
+        """Close down the thread."""
+        if not self.is_alive():
+            LOGGER.debug("Already Closed")
+            return "Already Closed"
+        self.exit_event.set()
+        # Put a value in the queue to push through the block waiting for items
+        # in the queue.
+        self.sql_queue.put(("", "", ""), timeout=5)
+        # Check that the thread is done before returning.
+        self.thread_closed.wait()
 
     @property
     def queue_size(self):
         """Return the queue size."""
         return self.sql_queue.qsize()
 
-    def query_results(self, token):
+    def _query_results(self, token):
         """Get the query results for a specific token.
 
         Args:
@@ -157,19 +169,14 @@ class Sqlite3Worker(threading.Thread):
         Returns:
             Return the results of the query when it's executed by the thread.
         """
-        delay = .001
-        while True:
-            if token in self.results:
-                return_val = self.results[token]
-                del self.results[token]
-                return return_val
-            # Double back on the delay to a max of 8 seconds.  This prevents
-            # a long lived select statement from trashing the CPU with this
-            # infinite loop as it's waiting for the query results.
-            LOGGER.debug("Sleeping: %s %s", delay, token)
-            time.sleep(delay)
-            if delay < 8:
-                delay += delay
+        try:
+            # Wait until the select query has executed
+            self.select_event.wait()
+            return_val = self.results[token]
+            del self.results[token]
+            return return_val
+        finally:
+            self.select_event.clear()
 
     def execute(self, query, values=None):
         """Execute a query.
@@ -181,7 +188,7 @@ class Sqlite3Worker(threading.Thread):
         Returns:
             If it's a select query it will return the results of the query.
         """
-        if self.exit_set:
+        if self.exit_event.is_set():
             LOGGER.debug("Exit set, not running: %s", query)
             return "Exit Called"
         LOGGER.debug("execute: %s", query)
@@ -192,6 +199,6 @@ class Sqlite3Worker(threading.Thread):
         # into the output queue so we know what results are ours.
         if query.lower().strip().startswith("select"):
             self.sql_queue.put((token, query, values), timeout=5)
-            return self.query_results(token)
+            return self._query_results(token)
         else:
             self.sql_queue.put((token, query, values), timeout=5)

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -27,6 +27,7 @@ __license__ = "MIT"
 
 import logging
 import sqlite3
+import time
 import threading
 import uuid
 
@@ -172,6 +173,8 @@ class Sqlite3Worker(threading.Thread):
         try:
             # Wait until the select query has executed
             self._select_event.wait()
+            while token not in self._results:
+                time.sleep(.1)
             return_val = self._results[token]
             del self._results[token]
             return return_val

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -25,15 +25,15 @@ __email__ = "shawnl@palantir.com"
 __license__ = "MIT"
 
 import logging
+import platform
+import os
+import sqlite3
+import threading
+import time
 try:
 	import queue as Queue # module re-named in Python 3
 except ImportError: # pragma: no cover
 	import Queue
-import pathlib # pip install pathlib
-import platform
-import sqlite3
-import threading
-import time
 
 LOGGER = logging.getLogger('sqlite3worker')
 
@@ -145,7 +145,7 @@ def normalize_file_name ( file_name ):
 	if file_name.lower() == ':memory:':
 		return ':memory:'
 	# lookup absolute path of file_name
-	file_name = str ( pathlib.Path ( file_name ).absolute() )
+	file_name = os.path.abspath ( file_name )
 	if platform.system() == 'Windows':
 		file_name = file_name.lower() # Windows filenames are not case-sensitive
 	return file_name

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -26,172 +26,345 @@ __license__ = "MIT"
 
 import logging
 try:
-    import queue as Queue # module re-named in Python 3
-except ImportError:
-    import Queue
+	import queue as Queue # module re-named in Python 3
+except ImportError: # pragma: no cover
+	import Queue
+import pathlib # pip install pathlib
+import platform
 import sqlite3
 import threading
 import time
-import uuid
 
 LOGGER = logging.getLogger('sqlite3worker')
 
+workers = {}
 
-class Sqlite3Worker(threading.Thread):
-    """Sqlite thread safe object.
+OperationalError = sqlite3.OperationalError
+Row = sqlite3.Row
 
-    Example:
-        from sqlite3worker import Sqlite3Worker
-        sql_worker = Sqlite3Worker("/tmp/test.sqlite")
-        sql_worker.execute(
-            "CREATE TABLE tester (timestamp DATETIME, uuid TEXT)")
-        sql_worker.execute(
-            "INSERT into tester values (?, ?)", ("2010-01-01 13:00:00", "bow"))
-        sql_worker.execute(
-            "INSERT into tester values (?, ?)", ("2011-02-02 14:14:14", "dog"))
-        sql_worker.execute("SELECT * from tester")
-        sql_worker.close()
-    """
-    def __init__(self, file_name, max_queue_size=100):
-        """Automatically starts the thread.
+class Frozen_object ( object ):
+	def __setattr__ ( self, key, value ):
+		if key not in dir ( self ): # prevent from accidentally creating new attributes
+			raise AttributeError ( '{!r} object has no attribute {!r}'.format ( type ( self ).__name__, key ) )
+		super ( Frozen_object, self ).__setattr__ ( key, value )
 
-        Args:
-            file_name: The name of the file.
-            max_queue_size: The max queries that will be queued.
-        """
-        threading.Thread.__init__(self)
-        self.daemon = True
-        self.sqlite3_conn = sqlite3.connect(
-            file_name, check_same_thread=False,
-            detect_types=sqlite3.PARSE_DECLTYPES)
-        self.sqlite3_cursor = self.sqlite3_conn.cursor()
-        self.sql_queue = Queue.Queue(maxsize=max_queue_size)
-        self.results = {}
-        self.max_queue_size = max_queue_size
-        self.exit_set = False
-        # Token that is put into queue when close() is called.
-        self.exit_token = str(uuid.uuid4())
-        self.start()
-        self.thread_running = True
+class Sqlite3WorkerRequest ( Frozen_object ):
+	def execute ( self ): # pragma: no cover
+		raise NotImplementedError ( type ( self ).__name__ + '.execute()' )
 
-    def run(self):
-        """Thread loop.
+class Sqlite3WorkerSetRowFactory ( Sqlite3WorkerRequest ):
+	worker = None
+	row_factory = None
+	
+	def __init__ ( self, worker, row_factory ):
+		self.worker = worker
+		self.row_factory = row_factory
+	
+	def execute ( self ):
+		self.worker.sqlite3_cursor.row_factory = self.row_factory
 
-        This is an infinite loop.  The iter method calls self.sql_queue.get()
-        which blocks if there are not values in the queue.  As soon as values
-        are placed into the queue the process will continue.
+class Sqlite3WorkerSetTextFactory ( Sqlite3WorkerRequest ):
+	worker = None
+	text_factory = None
+	
+	def __init__ ( self, worker, text_factory ):
+		self.worker = worker
+		self.text_factory = text_factory
+	
+	def execute ( self ):
+		self.worker.sqlite3_conn.text_factory = self.text_factory
 
-        If many executes happen at once it will churn through them all before
-        calling commit() to speed things up by reducing the number of times
-        commit is called.
-        """
-        LOGGER.debug("run: Thread started")
-        execute_count = 0
-        for token, query, values in iter(self.sql_queue.get, None):
-            LOGGER.debug("sql_queue: %s", self.sql_queue.qsize())
-            if token != self.exit_token:
-                LOGGER.debug("run: %s", query)
-                self.run_query(token, query, values)
-                execute_count += 1
-                # Let the executes build up a little before committing to disk
-                # to speed things up.
-                if (
-                        self.sql_queue.empty() or
-                        execute_count == self.max_queue_size):
-                    LOGGER.debug("run: commit")
-                    self.sqlite3_conn.commit()
-                    execute_count = 0
-            # Only exit if the queue is empty. Otherwise keep getting
-            # through the queue until it's empty.
-            if self.exit_set and self.sql_queue.empty():
-                self.sqlite3_conn.commit()
-                self.sqlite3_conn.close()
-                self.thread_running = False
-                return
+class Sqlite3WorkerExecute ( Sqlite3WorkerRequest ):
+	worker = None
+	query = None
+	values = None
+	results = None
+	
+	def __init__ ( self, worker, query, values ):
+		self.worker = worker
+		self.query = query
+		self.values = values
+		self.results = Queue.Queue()
+	
+	def execute ( self ):
+		LOGGER.debug ( "run execute: %s", self.query )
+		worker = self.worker
+		cur = worker.sqlite3_cursor
+		try:
+			cur.execute ( self.query, self.values )
+			result = ( cur.fetchall(), cur.description, cur.lastrowid )
+			success = True
+		except Exception as err:
+			LOGGER.error (
+				"Unhandled Exception in Sqlite3WorkerExecute.execute: {!r}".format ( err ) )
+			result = err
+			success = False
+		self.results.put ( ( success, result ) )
 
-    def run_query(self, token, query, values):
-        """Run a query.
+class Sqlite3WorkerExecuteScript ( Sqlite3WorkerRequest ):
+	worker = None
+	query = None
+	results = None
+	
+	def __init__ ( self, worker, query ):
+		self.worker = worker
+		self.query = query
+		self.results = Queue.Queue()
+	
+	def execute ( self ):
+		LOGGER.debug ( "run executescript: %s", self.query )
+		worker = self.worker
+		cur = worker.sqlite3_cursor
+		try:
+			cur.executescript ( self.query )
+			result = ( cur.fetchall(), cur.description, cur.lastrowid )
+			success = True
+		except Exception as err:
+			LOGGER.error (
+				"Unhandled Exception in Sqlite3WorkerExecuteScript.execute: {!r}".format ( err ) )
+			result = err
+			success = False
+		self.results.put ( ( success, result ) )
 
-        Args:
-            token: A uuid object of the query you want returned.
-            query: A sql query with ? placeholders for values.
-            values: A tuple of values to replace "?" in query.
-        """
-        if query.lower().strip().startswith("select"):
-            try:
-                self.sqlite3_cursor.execute(query, values)
-                self.results[token] = self.sqlite3_cursor.fetchall()
-            except sqlite3.Error as err:
-                # Put the error into the output queue since a response
-                # is required.
-                self.results[token] = (
-                    "Query returned error: %s: %s: %s" % (query, values, err))
-                LOGGER.error(
-                    "Query returned error: %s: %s: %s", query, values, err)
-        else:
-            try:
-                self.sqlite3_cursor.execute(query, values)
-            except sqlite3.Error as err:
-                LOGGER.error(
-                    "Query returned error: %s: %s: %s", query, values, err)
+class Sqlite3WorkerCommit ( Sqlite3WorkerRequest ):
+	worker = None
+	
+	def __init__ ( self, worker ):
+		self.worker = worker
+	
+	def execute ( self ):
+		LOGGER.debug("run commit")
+		worker = self.worker
+		worker.sqlite3_conn.commit()
 
-    def close(self):
-        """Close down the thread and close the sqlite3 database file."""
-        self.exit_set = True
-        self.sql_queue.put((self.exit_token, "", ""), timeout=5)
-        # Sleep and check that the thread is done before returning.
-        while self.thread_running:
-            time.sleep(.01)  # Don't kill the CPU waiting.
+class Sqlite3WorkerExit ( Exception, Sqlite3WorkerRequest ):
+	def execute ( self ):
+		raise self
 
-    @property
-    def queue_size(self):
-        """Return the queue size."""
-        return self.sql_queue.qsize()
+def normalize_file_name ( file_name ):
+	if file_name.lower() == ':memory:':
+		return ':memory:'
+	# lookup absolute path of file_name
+	file_name = str ( pathlib.Path ( file_name ).absolute() )
+	if platform.system() == 'Windows':
+		file_name = file_name.lower() # Windows filenames are not case-sensitive
+	return file_name
 
-    def query_results(self, token):
-        """Get the query results for a specific token.
+class Sqlite3Worker ( Frozen_object ):
+	"""Sqlite thread safe object.
+	Example:
+		from sqlite3worker import Sqlite3Worker
+		sql_worker = Sqlite3Worker("/tmp/test.sqlite")
+		sql_worker.execute(
+			"CREATE TABLE tester (timestamp DATETIME, uuid TEXT)")
+		sql_worker.execute(
+			"INSERT into tester values (?, ?)", ("2010-01-01 13:00:00", "bow"))
+		sql_worker.execute(
+			"INSERT into tester values (?, ?)", ("2011-02-02 14:14:14", "dog"))
+		sql_worker.execute("SELECT * from tester")
+		sql_worker.close()
+	"""
+	file_name = None
+	sqlite3_conn = None
+	sqlite3_cursor = None
+	sql_queue = None
+	max_queue_size = None
+	exit_set = False
+	_thread = None
+	
+	def __init__ ( self, file_name, max_queue_size=100 ):
+		"""Automatically starts the thread.
+		Args:
+			file_name: The name of the file.
+			max_queue_size: The max queries that will be queued.
+		"""
+		self._thread = threading.Thread ( target=self.run )
+		self._thread.daemon = True
+		
+		self.file_name = normalize_file_name ( file_name )
+		if self.file_name != ':memory:':
+			global workers
+			assert file_name not in workers, 'attempted to create two different Sqlite3Worker objects that reference the same database'
+			workers[file_name] = self
+		
+		self.sqlite3_conn = sqlite3.connect (
+			file_name, check_same_thread=False,
+			#detect_types=sqlite3.PARSE_DECLTYPES
+		)
+		self.sqlite3_cursor = self.sqlite3_conn.cursor()
+		self.sql_queue = Queue.Queue ( maxsize=max_queue_size )
+		self.max_queue_size = max_queue_size
+		self._thread.name = self._thread.name.replace ( 'Thread-', 'sqlite3worker-' )
+		self._thread.start()
+	
+	def run ( self ):
+		"""Thread loop.
+		This is an infinite loop.  The iter method calls self.sql_queue.get()
+		which blocks if there are not values in the queue.  As soon as values
+		are placed into the queue the process will continue.
+		If many executes happen at once it will churn through them all before
+		calling commit() to speed things up by reducing the number of times
+		commit is called.
+		"""
+		LOGGER.debug("run: Thread started")
+		while True:
+			try:
+				self.sql_queue.get().execute()
+			except Sqlite3WorkerExit as e:
+				if not self.sql_queue.empty(): # pragma: no cover ( TODO FIXME: come back to this )
+					self.sql_queue.put ( e ) # push the exit event to the end of the queue
+					continue
+				self.sqlite3_conn.commit()
+				self.sqlite3_conn.close()
+				if self.file_name != ':memory:':
+					global workers
+					del workers[self.file_name]
+				return
+	
+	def close ( self ):
+		"""Close down the thread and close the sqlite3 database file."""
+		if self.exit_set: # pragma: no cover
+			LOGGER.debug ( "Exit set, not running: %s", query )
+			raise OperationalError ( 'sqlite worker thread already shutting down' )
+		self.exit_set = True
+		self.sql_queue.put ( Sqlite3WorkerExit(), timeout=5 )
+		# Sleep and check that the thread is done before returning.
+		self._thread.join()
+	
+	@property
+	def queue_size ( self ): # pragma: no cover
+		"""Return the queue size."""
+		return self.sql_queue.qsize()
+	
+	def set_row_factory ( self, row_factory ):
+		self.sql_queue.put ( Sqlite3WorkerSetRowFactory ( self, row_factory ), timeout=5 )
+	
+	def set_text_factory ( self, text_factory ):
+		self.sql_queue.put ( Sqlite3WorkerSetTextFactory ( self, text_factory ), timeout=5 )
+	
+	def execute_ex ( self, query, values=None ):
+		"""Execute a query.
+		Args:
+			query: The sql string using ? for placeholders of dynamic values.
+			values: A tuple of values to be replaced into the ? of the query.
+		Returns:
+			a tuple of ( rows, description, lastrowid ):
+				rows is a list of row results returned by fetchall() or [] if no rows
+				description is the results of cursor.description after executing the query
+				lastrowid is the result of calling cursor.lastrowid after executing the query
+		"""
+		if self.exit_set: # pragma: no cover
+			LOGGER.debug ( "Exit set, not running: %s", query )
+			raise OperationalError ( 'sqlite worker thread already shutting down' )
+		LOGGER.debug ( "request execute: %s", query )
+		r = Sqlite3WorkerExecute ( self, query, values or [] )
+		self.sql_queue.put ( r, timeout=5 )
+		success, result = r.results.get()
+		if not success:
+			raise result
+		else:
+			return result
+	
+	def execute ( self, query, values=None ):
+		return self.execute_ex ( query, values )[0]
+	
+	def executescript_ex ( self, query ):
+		if self.exit_set: # pragma: no cover
+			LOGGER.debug ( "Exit set, not running: %s", query )
+			raise OperationalError ( 'sqlite worker thread already shutting down' )
+		LOGGER.debug ( "request executescript: %s", query )
+		r = Sqlite3WorkerExecuteScript ( self, query )
+		self.sql_queue.put ( r, timeout=5 )
+		success, result = r.results.get()
+		if not success:
+			raise result
+		else:
+			return result
+	
+	def executescript ( self, sql ):
+		return self.executescript_ex ( sql )[0]
+	
+	def commit ( self ):
+		if self.exit_set: # pragma: no cover
+			LOGGER.debug ( "Exit set, not running: %s", query )
+			raise OperationalError ( 'sqlite worker thread already shutting down' )
+		LOGGER.debug ( "request commit" )
+		self.sql_queue.put ( Sqlite3WorkerCommit ( self ), timeout=5 )
 
-        Args:
-            token: A uuid object of the query you want returned.
+class Sqlite3worker_dbapi_cursor ( Frozen_object ):
+	con = None
+	rows = None
+	description = None
+	lastrowid = None
+	
+	def __init__ ( self, con ):
+		self.con = con
+	
+	def close ( self ):
+		pass
+	
+	def execute ( self, sql, values=None ):
+		self.rows, self.description, self.lastrowid = self.con.worker.execute_ex ( sql, values )
+	
+	def executescript ( self, sql_script ):
+		self.rows, self.description, self.lastrowid = self.con.worker.executescript_ex ( sql_script )
+	
+	def fetchone ( self ):
+		try:
+			return self.rows.pop ( 0 )
+		except IndexError:
+			return None
+	
+	def __iter__ ( self ):
+		while self.rows:
+			yield self.fetchone()
 
-        Returns:
-            Return the results of the query when it's executed by the thread.
-        """
-        delay = .001
-        while True:
-            if token in self.results:
-                return_val = self.results[token]
-                del self.results[token]
-                return return_val
-            # Double back on the delay to a max of 8 seconds.  This prevents
-            # a long lived select statement from trashing the CPU with this
-            # infinite loop as it's waiting for the query results.
-            LOGGER.debug("Sleeping: %s %s", delay, token)
-            time.sleep(delay)
-            if delay < 8:
-                delay += delay
+class Sqlite3worker_dbapi_connection ( Frozen_object ):
+	worker = None
+	
+	def __init__ ( self, worker ):
+		self.worker = worker
+	
+	def commit ( self ):
+		self.worker.commit()
+	
+	def cursor ( self ):
+		return Sqlite3worker_dbapi_cursor ( self )
+	
+	def execute ( self, sql, values=None ):
+		cur = self.cursor()
+		cur.execute ( sql, values )
+		return cur
+	
+	def executescript ( self, sql_script ):
+		cur = self.cursor()
+		cur.executescript ( sql_script )
+		return cur
+	
+	def close ( self ):
+		self.worker.close()
+	
+	@property
+	def row_factory ( self ):
+		raise NotImplementedError ( type ( self ).__name__ + '.row_factory' )
+	
+	@row_factory.setter
+	def row_factory ( self, row_factory ):
+		self.worker.set_row_factory ( row_factory )
+	
+	@property
+	def text_factory ( self ):
+		raise NotImplementedError ( type ( self ).__name__ + '.text_factory' )
+	
+	@text_factory.setter
+	def text_factory ( self, text_factory ):
+		self.worker.set_text_factory ( text_factory )
 
-    def execute(self, query, values=None):
-        """Execute a query.
-
-        Args:
-            query: The sql string using ? for placeholders of dynamic values.
-            values: A tuple of values to be replaced into the ? of the query.
-
-        Returns:
-            If it's a select query it will return the results of the query.
-        """
-        if self.exit_set:
-            LOGGER.debug("Exit set, not running: %s", query)
-            return "Exit Called"
-        LOGGER.debug("execute: %s", query)
-        values = values or []
-        # A token to track this query with.
-        token = str(uuid.uuid4())
-        # If it's a select we queue it up with a token to mark the results
-        # into the output queue so we know what results are ours.
-        if query.lower().strip().startswith("select"):
-            self.sql_queue.put((token, query, values), timeout=5)
-            return self.query_results(token)
-        else:
-            self.sql_queue.put((token, query, values), timeout=5)
+def connect ( file_name ):
+	file_name = normalize_file_name ( file_name )
+	global workers
+	try:
+		worker = workers[file_name]
+	except KeyError:
+		worker = Sqlite3Worker ( file_name )
+	return Sqlite3worker_dbapi_connection ( worker )

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -69,7 +69,7 @@ class Sqlite3Worker(threading.Thread):
         self._sqlite3_cursor = self._sqlite3_conn.cursor()
         self._sql_queue = Queue.Queue(maxsize=max_queue_size)
         self._results = {}
-        self.max_queue_size = max_queue_size
+        self._max_queue_size = max_queue_size
         # Event that is triggered once the run_query has been executed.
         self._select_event = threading.Event()
         # Event to start the exit process.
@@ -101,7 +101,7 @@ class Sqlite3Worker(threading.Thread):
                 # to speed things up.
                 if (
                         self._sql_queue.empty() or
-                        execute_count == self.max_queue_size):
+                        execute_count == self._max_queue_size):
                     LOGGER.debug("run: commit")
                     self._sqlite3_conn.commit()
                     execute_count = 0

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -174,8 +174,7 @@ class Sqlite3Worker(threading.Thread):
             # Wait until the select query has executed
             self._select_events.setdefault(token, threading.Event())
             self._select_events[token].wait()
-            return_val = self._results[token]
-            return return_val
+            return self._results[token]
         finally:
             self._select_events[token].clear()
             del self._results[token]

--- a/sqlite3worker.py
+++ b/sqlite3worker.py
@@ -246,10 +246,10 @@ class Sqlite3Worker ( Frozen_object ):
 				self._thread._sql_queue.put ( Sqlite3WorkerExit(), timeout=5 )
 				# wait for the thread to finish what it's doing and shut down
 				self._thread.join()
-			try:
-				del self._threads[self._file_name]
-			except KeyError:
-				assert self._file_name == ':memory:'
+				try:
+					del self._threads[self._file_name]
+				except KeyError:
+					assert self._file_name == ':memory:'
 	
 	@property
 	def queue_size ( self ): # pragma: no cover

--- a/sqlite3worker_test.py
+++ b/sqlite3worker_test.py
@@ -28,6 +28,7 @@ __license__ = "MIT"
 
 import logging
 import os
+import sys
 import tempfile
 import threading
 import time
@@ -37,6 +38,8 @@ import unittest
 
 import sqlite3worker
 
+if sys.version_info[0] >= 3:
+	unicode = str
 
 class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
     """Test out the sqlite3worker library."""
@@ -206,9 +209,9 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
         for row in cur:
             self.assertEqual ( len ( row['uuid'] ), 36 )
             count += 1
-        self.assertEquals ( cur.fetchone(), None ) # make sure all rows retrieved
+        self.assertEqual ( cur.fetchone(), None ) # make sure all rows retrieved
         con.close()
-        self.assertEquals ( count, 25 )
+        self.assertEqual ( count, 25 )
     
     def test_coverage ( self ):
         """ a bunch of miscellaneous things to get code coverage to 100% """
@@ -218,7 +221,7 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
         with self.assertRaises ( AttributeError ):
             foo.bar = 'bar'
         self.sqlite3worker.set_row_factory ( sqlite3worker.Row )
-        self.assertEquals ( self.sqlite3worker.total_changes, 0 )
+        self.assertEqual ( self.sqlite3worker.total_changes, 0 )
         self.sqlite3worker.set_text_factory ( unicode )
         with self.assertRaises ( sqlite3worker.OperationalError ):
             self.sqlite3worker.executescript ( 'THIS IS INTENTIONALLY BAD SQL' )
@@ -228,7 +231,7 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
         with self.assertRaises ( AssertionError ):
             self.sqlite3worker.close()
         
-        self.assertEquals ( sqlite3worker.normalize_file_name ( ':MEMORY:' ), ':memory:' )
+        self.assertEqual ( sqlite3worker.normalize_file_name ( ':MEMORY:' ), ':memory:' )
         with self.assertRaises ( sqlite3worker.ProgrammingError ):
             self.sqlite3worker.executescript ( 'drop table tester' )
         with self.assertRaises ( sqlite3worker.ProgrammingError ):

--- a/sqlite3worker_test.py
+++ b/sqlite3worker_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright (c) 2014 Palantir Technologies
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,12 +23,15 @@
 """sqlite3worker test routines."""
 
 __author__ = "Shawn Lee"
-__email__ = "shawnl@palantir.com"
+__email__ = "dashawn@gmail.com"
 __license__ = "MIT"
 
 import os
 import tempfile
+import threading
 import time
+import uuid
+
 import unittest
 
 import sqlite3worker
@@ -35,7 +39,8 @@ import sqlite3worker
 
 class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
     """Test out the sqlite3worker library."""
-    def setUp(self):  # pylint:disable=C0103
+
+    def setUp(self):  # pylint:disable=D0102
         self.tmp_file = tempfile.NamedTemporaryFile(
             suffix="pytest", prefix="sqlite").name
         self.sqlite3worker = sqlite3worker.Sqlite3Worker(self.tmp_file)
@@ -43,23 +48,24 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
         self.sqlite3worker.execute(
             "CREATE TABLE tester (timestamp DATETIME, uuid TEXT)")
 
-    def tearDown(self):  # pylint:disable=C0103
-        self.sqlite3worker.close()
+    def tearDown(self):  # pylint:disable=D0102
+        try:
+            self.sqlite3worker.close()
+        except sqlite3worker.OperationalError:
+            pass # the test may have already closed the database
         os.unlink(self.tmp_file)
 
     def test_bad_select(self):
         """Test a bad select query."""
         query = "select THIS IS BAD SQL"
-        self.assertEqual(
-            self.sqlite3worker.execute(query),
-            (
-                "Query returned error: select THIS IS BAD SQL: "
-                "[]: no such column: THIS"))
+        with self.assertRaises ( sqlite3worker.OperationalError ):
+            self.sqlite3worker.execute(query)
 
     def test_bad_insert(self):
         """Test a bad insert query."""
         query = "insert THIS IS BAD SQL"
-        self.sqlite3worker.execute(query)
+        with self.assertRaises ( sqlite3worker.OperationalError ):
+            self.sqlite3worker.execute(query)
         # Give it one second to clear the queue.
         if self.sqlite3worker.queue_size != 0:
             time.sleep(1)
@@ -82,6 +88,60 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
         self.assertEqual(
             self.sqlite3worker.execute("SELECT * from tester"),
             [("2010-01-01 13:00:00", "bow"), ("2011-02-02 14:14:14", "dog")])
+
+    def test_run_after_close(self):
+        """Test to make sure all events are cleared after object closed."""
+        self.sqlite3worker.close()
+        with self.assertRaises ( sqlite3worker.OperationalError ):
+            self.sqlite3worker.execute(
+                "INSERT into tester values (?, ?)", ("2010-01-01 13:00:00", "bow"))
+
+    def test_double_close(self):
+        """Make sure double closeing messages properly."""
+        self.sqlite3worker.close()
+        with self.assertRaises ( sqlite3worker.OperationalError ):
+            self.sqlite3worker.close()
+
+    def test_db_closed_properly(self):
+        """Make sure sqlite object is properly closed out."""
+        self.sqlite3worker.close()
+        with self.assertRaises(
+                self.sqlite3worker._sqlite3_conn.ProgrammingError):
+            self.sqlite3worker._sqlite3_conn.total_changes
+
+    def test_many_threads(self):
+        """Make sure lots of threads work together."""
+        class threaded(threading.Thread):
+            def __init__(self, sqlite_obj):
+                threading.Thread.__init__(self, name=__name__)
+                self.sqlite_obj = sqlite_obj
+                self.daemon = True
+                self.failed = False
+                self.completed = False
+                self.start()
+
+            def run(self):
+                for _ in range(5):
+                    token = str(uuid.uuid4())
+                    self.sqlite_obj.execute(
+                        "INSERT into tester values (?, ?)",
+                        ("2010-01-01 13:00:00", token))
+                    resp = self.sqlite_obj.execute(
+                        "SELECT * from tester where uuid = ?", (token,))
+                    if resp != [("2010-01-01 13:00:00", token)]:
+                        self.failed = True
+                        break
+                self.completed = True
+
+        threads = []
+        for _ in range(5):
+            threads.append(threaded(self.sqlite3worker))
+
+        for i in range(5):
+            while not threads[i].completed:
+                time.sleep(.1)
+            self.assertEqual(threads[i].failed, False)
+            threads[i].join()
 
 
 if __name__ == "__main__":

--- a/sqlite3worker_test.py
+++ b/sqlite3worker_test.py
@@ -104,8 +104,8 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
         """Make sure sqlite object is properly closed out."""
         self.sqlite3worker.close()
         with self.assertRaises(
-                self.sqlite3worker.sqlite3_conn.ProgrammingError):
-            self.sqlite3worker.sqlite3_conn.total_changes
+                self.sqlite3worker._sqlite3_conn.ProgrammingError):
+            self.sqlite3worker._sqlite3_conn.total_changes
 
 
 if __name__ == "__main__":

--- a/sqlite3worker_test.py
+++ b/sqlite3worker_test.py
@@ -121,7 +121,7 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
                 self.start()
 
             def run(self):
-                for _ in range(100):
+                for _ in range(5):
                     token = str(uuid.uuid4())
                     self.sqlite_obj.execute(
                         "INSERT into tester values (?, ?)",
@@ -134,10 +134,10 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
                 self.completed = True
 
         threads = []
-        for _ in range(100):
+        for _ in range(5):
             threads.append(threaded(self.sqlite3worker))
 
-        for i in range(100):
+        for i in range(5):
             while not threads[i].completed:
                 time.sleep(.1)
             self.assertEqual(threads[i].failed, False)

--- a/sqlite3worker_test.py
+++ b/sqlite3worker_test.py
@@ -41,8 +41,8 @@ class Sqlite3WorkerTests(unittest.TestCase):  # pylint:disable=R0904
     """Test out the sqlite3worker library."""
 
     def setUp(self):  # pylint:disable=D0102
-        self.tmp_file = tempfile.NamedTemporaryFile(
-            suffix="pytest", prefix="sqlite").name
+        self.tmp_file = tempfile.mktemp(
+            suffix="pytest", prefix="sqlite")
         self.sqlite3worker = sqlite3worker.Sqlite3Worker(self.tmp_file)
         # Create sql db.
         self.sqlite3worker.execute(


### PR DESCRIPTION
I found sqlite3worker extremely helpful to me, and made a number of enhancements that I wanted to share back with the project:

1) dbapi compatible interface that implements enough features to be a drop-in replacement for 3 different database abstraction libraries that I use. This can be dropped by replacing "import sqlite3" with "import sqlite3worker as sqlite3"

2) use Queue objects in place of uuid tokens, this simplifies several code constructs including the back-off delay while waiting for a response.

3) eliminate auto-commit and support commit calls directly giving user complete control of how often they want to commit.

4) catch exceptions and throw in caller's thread

5) eliminate need for "thread_running" attribute by using threading.Thread.join()

6) Try to protect the user from accidentally opening two different worker objects on the same database.