### PR TITLE
execute_with_columns method to allow users to retrieve also column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,6 @@ Installation is via the usual ``setup.py`` method:
 sudo python setup.py install
 ```
 
-Alternatively one can use ``pip`` to install directly from the git repository
-without having to clone first:
-
-```sh
-sudo pip install git+https://github.com/palantir/sqlite3worker#egg=sqlite3worker
-```
-
-One may also use ``pip`` to install on a per-user basis without requiring
-super-user permissions:
-
-```sh
-pip install --user git+https://github.com/palantir/sqlite3worker#egg=sqlite3worker
-```
 
 ## Example
 ```python
@@ -41,6 +28,10 @@ sql_worker.execute("INSERT into tester values (?, ?)", ("2010-01-01 13:00:00", "
 sql_worker.execute("INSERT into tester values (?, ?)", ("2011-02-02 14:14:14", "dog"))
 
 results = sql_worker.execute("SELECT * from tester")
+for timestamp, uuid in results:
+    print(timestamp, uuid)
+
+results, columns = sql_worker.execute_with_columns("SELECT * from tester")
 for timestamp, uuid in results:
     print(timestamp, uuid)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fork of Sqlite3Worker
 
-Sqlite3Worker is a threadsafe sqlite worker.
+Sqlite3Worker is a threadsafe sqlite worker.  
 In this fork we added the possibility to retrieve the columns' names (heading) from the query by using the "execute_with_columns" method instead of the "execute" one.  
 To do it you can use the following structure:  
     ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Sqlite3Worker
+# Fork of Sqlite3Worker
 
-A threadsafe sqlite worker.
+Sqlite3Worker is a threadsafe sqlite worker.
+In this fork we added the possibility to retrieve the columns' names (heading) from the query by using the "execute_with_columns" method instead of the "execute" one.  
+To do it you can use the following structure:  
+    ```
+    rows, columns = sql_worker.execute_with_columns("SELECT * from tester")
+    ```
 
-This library implements a thread pool pattern with sqlite3 being the desired
+This library (thanks to the one from which it was forked) implements a thread pool pattern with sqlite3 being the desired
 output.
 
 sqllite3 implementation lacks the ability to safely modify the sqlite3 database


### PR DESCRIPTION
execute_with_columns method to allow users to retrieve also column names.
Maybe a better integration is possible, but it was the easiest and fastest way to do it with a compatibility with old structure

To use it:
```
rows, columns = sql_worker.execute_with_columns("SELECT * from tester")
```